### PR TITLE
Add config struct for UART initialization.

### DIFF
--- a/sg2000-hal/src/clock.rs
+++ b/sg2000-hal/src/clock.rs
@@ -1,0 +1,40 @@
+pub trait ClockSource {
+    fn hz(&self) -> Rate;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Rate(u64);
+
+impl Rate {
+    pub fn from_hz(hz: u64) -> Self {
+        Self(hz)
+    }
+
+    pub fn from_khz(khz: u64) -> Self {
+        Self(khz * 1_000)
+    }
+
+    pub fn from_mhz(mhz: u64) -> Self {
+        Self(mhz * 1_000_000)
+    }
+
+    pub fn from_ghz(ghz: u64) -> Self {
+        Self(ghz * 1_000_000_000)
+    }
+
+    pub fn as_hz(&self) -> u64 {
+        self.0
+    }
+
+    pub fn as_khz(&self) -> u64 {
+        self.0 / 1_000
+    }
+
+    pub fn as_mhz(&self) -> u64 {
+        self.0 / 1_000_000
+    }
+
+    pub fn as_ghz(&self) -> u64 {
+        self.0 / 1_000_000_000
+    }
+}

--- a/sg2000-hal/src/lib.rs
+++ b/sg2000-hal/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 
 pub use sg2000_pac as pac;
+pub mod clock;
 pub mod irq;
 pub mod resource_table;
 pub mod uart;

--- a/sg2000-hal/src/uart/config.rs
+++ b/sg2000-hal/src/uart/config.rs
@@ -1,0 +1,119 @@
+use crate::clock::{ClockSource, Rate};
+
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy)]
+pub struct Config {
+    clock: SourceClock,
+    baud_rate: u32,
+    data_len: DataLen,
+    stop_bits: StopBits,
+    parity: ParityMode,
+}
+
+impl Config {
+    pub fn clock(&self) -> SourceClock {
+        self.clock
+    }
+
+    pub fn baud_rate(&self) -> u32 {
+        self.baud_rate
+    }
+
+    pub fn data_len(&self) -> DataLen {
+        self.data_len
+    }
+
+    pub fn stop_bits(&self) -> StopBits {
+        self.stop_bits
+    }
+
+    pub fn parity(&self) -> ParityMode {
+        self.parity
+    }
+
+    pub fn with_clock(mut self, clock: SourceClock) -> Self {
+        self.clock = clock;
+        self
+    }
+
+    pub fn with_baud_rate(mut self, baud_rate: u32) -> Self {
+        self.baud_rate = baud_rate;
+        self
+    }
+
+    pub fn with_data_len(mut self, data_len: DataLen) -> Self {
+        self.data_len = data_len;
+        self
+    }
+
+    pub fn with_stop_bits(mut self, stop_bits: StopBits) -> Self {
+        self.stop_bits = stop_bits;
+        self
+    }
+
+    pub fn with_parity(mut self, parity: ParityMode) -> Self {
+        self.parity = parity;
+        self
+    }
+
+    pub(crate) fn validate(&self) -> bool {
+        self.stop_bits == StopBits::One
+            || self.stop_bits == StopBits::OnePFive && self.data_len == DataLen::Five
+            || self.stop_bits == StopBits::Two && self.data_len != DataLen::Five
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            clock: Default::default(),
+            baud_rate: 115200,
+            data_len: Default::default(),
+            stop_bits: Default::default(),
+            parity: Default::default(),
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum SourceClock {
+    #[default]
+    Xtal,
+    // DispPLL,
+}
+
+impl ClockSource for SourceClock {
+    fn hz(&self) -> Rate {
+        match self {
+            SourceClock::Xtal => Rate::from_khz(25_000),
+            // SourceClock::DispPLL => Rate::from_khz(187_500),
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum DataLen {
+    Five,
+    Six,
+    Seven,
+    #[default]
+    Eight,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum StopBits {
+    One,
+    OnePFive,
+    #[default]
+    Two,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum ParityMode {
+    #[default]
+    None,
+    Odd,
+    Even,
+    Mark,
+    Space,
+}

--- a/synthgut/src/main.rs
+++ b/synthgut/src/main.rs
@@ -10,7 +10,7 @@ use sg2000_hal::{
     Config, init,
     irq::{enable_irq, set_handler},
     pac::{Uart1, interrupt::ExternalInterrupt},
-    uart::Uart,
+    uart::{self, Uart},
 };
 use static_cell::StaticCell;
 
@@ -31,7 +31,6 @@ fn panic(info: &PanicInfo) -> ! {
 
 static UART1: StaticCell<Uart1> = StaticCell::new();
 const BANNER: &str = "##############################################################";
-const XTAL_CLK: u32 = 25_000_000;
 
 #[embassy_executor::main]
 async fn main(spawner: Spawner) -> ! {
@@ -56,7 +55,7 @@ async fn main(spawner: Spawner) -> ! {
     Timer::after_secs(1).await;
 
     let mut uart1p = Uart::new(uart1, true);
-    uart1p.init(XTAL_CLK, 115200);
+    uart1p.init(uart::Config::default()).unwrap();
     writeln!(uart1p, "{BANNER}").await;
     writeln!(uart1p, "# Synthgut 0.1.0, built {BUILD_TIME} #").await;
     writeln!(uart1p, "{BANNER}").await;


### PR DESCRIPTION
Fixes #3. Note: decided against combining new and init functions to allow user to delay or avoid running init code if wanted.